### PR TITLE
Poetry - replace deprecated dev dependencies section in pyproject.toml

### DIFF
--- a/tests/test_project_generation.py
+++ b/tests/test_project_generation.py
@@ -1,3 +1,4 @@
+import pytest
 import yaml
 from pathlib import Path
 
@@ -13,8 +14,24 @@ EXAMPLE_CONTEXT = content['default_context']
 PROJECT_NAME = EXAMPLE_CONTEXT["project_name"]
 
 
-def test_generate_new_project(tmp_path):
-    path_to_new_project = cookiecutter(
+@pytest.fixture
+def generated_project_path(tmp_path) -> Path:
+    """
+    :return: path to newly generated project
+    """
+    return Path(cookiecutter(
         TEMPLATE_DIR, no_input=True, extra_context=EXAMPLE_CONTEXT, output_dir=tmp_path
-    )
-    assert path_to_new_project == str(tmp_path / PROJECT_NAME)
+    ))
+
+
+def test_generate_new_project(tmp_path, generated_project_path):
+
+    assert generated_project_path == tmp_path / PROJECT_NAME
+
+
+def test_poetry_uses_dev_group(generated_project_path):
+
+    pyproject_toml_content = generated_project_path.joinpath("pyproject.toml").read_text()
+
+    assert "dev-dependencies" not in pyproject_toml_content
+    assert "[tool.poetry.group.dev.dependencies]" in pyproject_toml_content.splitlines()

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -32,7 +32,8 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.7.1, <4.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
+autoflake = "*"
 black = "*"
 mkdocstrings = {version = ">=0.18", extras = ["python"]}
 mkdocs-material = "*"


### PR DESCRIPTION
Since Poetry v1.2 the flag `--dev` which creates `tool.poetry.dev-dependencies` in `pyproject.toml` is deprecated in favor of `tool.poetry.group.dev.dependencies`.