### PR TITLE
Add variable with python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.9
-      - run: python -m pip install cookiecutter pytest pyyaml
+      - run: python -m pip install cookiecutter pytest pyyaml toml
       - run: pytest
 
   lint-generated-project:

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,9 +1,43 @@
 {
-    "author_name": "Your name",
-    "author_email": "Your email address (eq. you@example.com)",
-    "github_username": "",
-    "project_name": "Name of the project (will be shown e.g. as the title in the readme)",
-    "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
-    "package_name": "{{ cookiecutter.project_slug.replace('-', '_') }}",
-    "project_short_description": "A short description of the project"
+  "author_name": "Your name",
+  "author_email": "Your email address (eq. you@example.com)",
+  "github_username": "",
+  "project_name": "Name of the project (will be shown e.g. as the title in the readme)",
+  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
+  "package_name": "{{ cookiecutter.project_slug.replace('-', '_') }}",
+  "project_short_description": "A short description of the project",
+  "python_version": [
+    "3.8+",
+    "3.9+",
+    "3.10+",
+    "3.11+"
+  ],
+  "_python_version_specs": {
+  "3.8+": {
+    "versions": [
+      "3.8",
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  "3.9+": {
+    "versions": [
+      "3.9",
+      "3.10",
+      "3.11"
+    ]
+  },
+  "3.10+": {
+    "versions": [
+      "3.10",
+      "3.11"
+    ]
+  },
+  "3.11+": {
+    "versions": [
+      "3.11"
+    ]
+  }
+}
 }

--- a/tests/context.yaml
+++ b/tests/context.yaml
@@ -4,3 +4,4 @@ default_context:
     github_username: "johndoe"
     project_name: "example-project"
     project_short_description: "A short description of the project"
+    python_version: "3.8+"

--- a/tests/test_project_generation.py
+++ b/tests/test_project_generation.py
@@ -1,4 +1,5 @@
 import pytest
+import toml
 import yaml
 from pathlib import Path
 
@@ -10,7 +11,7 @@ CONTEXT_FILE = Path(__file__).parent / "context.yaml"
 with open(CONTEXT_FILE) as file_handler:
     content = yaml.safe_load(file_handler)
 
-EXAMPLE_CONTEXT = content['default_context']
+EXAMPLE_CONTEXT = content["default_context"]
 PROJECT_NAME = EXAMPLE_CONTEXT["project_name"]
 
 
@@ -19,19 +20,50 @@ def generated_project_path(tmp_path) -> Path:
     """
     :return: path to newly generated project
     """
-    return Path(cookiecutter(
-        TEMPLATE_DIR, no_input=True, extra_context=EXAMPLE_CONTEXT, output_dir=tmp_path
-    ))
+    return Path(
+        cookiecutter(
+            TEMPLATE_DIR,
+            no_input=True,
+            extra_context=EXAMPLE_CONTEXT,
+            output_dir=tmp_path,
+        )
+    )
 
 
 def test_generate_new_project(tmp_path, generated_project_path):
-
     assert generated_project_path == tmp_path / PROJECT_NAME
 
 
 def test_poetry_uses_dev_group(generated_project_path):
-
-    pyproject_toml_content = generated_project_path.joinpath("pyproject.toml").read_text()
+    pyproject_toml_content = generated_project_path.joinpath(
+        "pyproject.toml"
+    ).read_text()
 
     assert "dev-dependencies" not in pyproject_toml_content
     assert "[tool.poetry.group.dev.dependencies]" in pyproject_toml_content.splitlines()
+
+
+def test_python_version_is_correctly_included_in_black_config(generated_project_path):
+    parsed_pyproject_toml = toml.loads(
+        generated_project_path.joinpath("pyproject.toml").read_text()
+    )
+
+    assert parsed_pyproject_toml["tool"]["black"]["target-version"] == [
+        "py38",
+        "py39",
+        "py310",
+        "py311",
+    ]
+
+
+# for gh test workflow
+def test_python_version_is_correctly_included_in_github_workflow(
+    generated_project_path,
+):
+    parsed_github_workflow = yaml.safe_load(
+        generated_project_path.joinpath(".github/workflows/test.yml").read_text()
+    )
+
+    assert parsed_github_workflow["jobs"]["test"]["strategy"]["matrix"][
+        "python-version"
+    ] == ["3.8", "3.9", "3.10", "3.11"]

--- a/{{cookiecutter.project_slug}}/.github/workflows/test.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/test.yml
@@ -32,16 +32,17 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/python-poetry-env
       - run: poetry run pre-commit run --all-files
+  {%- endraw %}
 
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: {{ cookiecutter._python_version_specs[cookiecutter.python_version].versions }}
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/python-poetry-env
         with:
-          python-version: ${{ matrix.python-version }}
-      - run: poetry run pytest{% endraw %}
+          python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
+      - run: poetry run pytest

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -29,7 +29,7 @@ pip install {{ cookiecutter.project_slug }}
 * Clone this repository
 * Requirements:
   * [Poetry](https://python-poetry.org/)
-  * Python 3.7+
+  * Python {{ cookiecutter.python_version }}
 * Create a virtual environment and install the dependencies
 
 ```sh

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -18,9 +18,9 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
+  {%- for version in cookiecutter._python_version_specs[cookiecutter.python_version]['versions'] %}
+  "Programming Language :: Python :: {{ version }}",
+  {%- endfor %}
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Typing :: Typed",
 ]
@@ -30,7 +30,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7.1, <4.0"
+python = ">={{ cookiecutter._python_version_specs[cookiecutter.python_version]['versions'][0] }}, <4.0"
 
 [tool.poetry.group.dev.dependencies]
 autoflake = "*"
@@ -52,7 +52,10 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.black]
-target-version = ["py37", "py38", "py39"]
+target-version = [{%- for version in cookiecutter._python_version_specs[cookiecutter.python_version]['versions'] %}
+    "py{{ version.replace('.', '') }}",
+    {%- endfor %}
+]
 include = '\.pyi?$'
 
 [tool.ruff]


### PR DESCRIPTION
`cookiecutter.json` includes now variable which stores the minimum supported Python version. 
`Ruff` handles it automatically basing on a version in `pyproject.toml`