### PR TITLE
Variable for defining whether the project will have a release cycle

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,6 +6,7 @@
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
   "package_name": "{{ cookiecutter.project_slug.replace('-', '_') }}",
   "project_short_description": "A short description of the project",
+  "releasable": true,
   "python_version": [
     "3.9+",
     "3.10+",
@@ -49,5 +50,10 @@
         "3.13"
       ]
     }
-  }
+  },
+  "__prompts__":
+  {
+    "releasable": "Do you want to version and release this package to PyPI?"
+  },
+  "_jinja2_env_vars": {"lstrip_blocks": true, "trim_blocks": true}
 }

--- a/tests/context.yaml
+++ b/tests/context.yaml
@@ -5,3 +5,4 @@ default_context:
     project_name: "example-project"
     project_short_description: "A short description of the project"
     python_version: "3.9+"
+    releasable: true

--- a/tests/test_project_generation.py
+++ b/tests/test_project_generation.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 import toml
 import yaml
@@ -15,20 +17,22 @@ EXAMPLE_CONTEXT = content["default_context"]
 PROJECT_NAME = EXAMPLE_CONTEXT["project_name"]
 
 
+def render_template(output_path: Path, context: dict[str, Any]) -> Path:
+    return Path(
+        cookiecutter(
+            TEMPLATE_DIR,
+            no_input=True,
+            extra_context=context,
+            output_dir=output_path,
+        ))
+
+
 @pytest.fixture
 def generated_project_path(tmp_path) -> Path:
     """
     :return: path to newly generated project
     """
-    return Path(
-        cookiecutter(
-            TEMPLATE_DIR,
-            no_input=True,
-            extra_context=EXAMPLE_CONTEXT,
-            output_dir=tmp_path,
-        )
-    )
-
+    return render_template(tmp_path, EXAMPLE_CONTEXT)
 
 def test_generate_new_project(tmp_path, generated_project_path):
     assert generated_project_path == tmp_path / PROJECT_NAME
@@ -50,14 +54,28 @@ def test_python_version_is_correctly_included_in_black_config(generated_project_
 
     assert parsed_pyproject_toml["tool"]["ruff"]["target-version"] == "py39"
 
+
 # for gh test workflow
 def test_python_version_is_correctly_included_in_github_workflow(
-    generated_project_path,
+        generated_project_path,
 ):
     parsed_github_workflow = yaml.safe_load(
         generated_project_path.joinpath(".github/workflows/test.yml").read_text()
     )
 
     assert parsed_github_workflow["jobs"]["test"]["strategy"]["matrix"][
-        "python-version"
-    ] == ["3.9", "3.10", "3.11", "3.12", "3.13"]
+               "python-version"
+           ] == ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
+
+def test_specific_files_and_packages_are_not_include_if_package_is_meant_to_be_not_releasable(tmp_path):
+    context = EXAMPLE_CONTEXT | {"releasable": False}
+    project_path = render_template(tmp_path, context)
+    for filename in ["CHANGELOG.md", "release.yml", "draft_release.yml"]:
+        assert filename in (project_path / ".gitignore").read_text()
+
+    parsed_pyproject_toml = toml.loads(
+        project_path.joinpath("pyproject.toml").read_text()
+    )
+    assert "python-kacl" not in parsed_pyproject_toml["tool"]["poetry"]["group"]["dev"]["dependencies"]
+    assert "pypi" not in Path(project_path / "README.md").read_text().lower()

--- a/{{cookiecutter.project_slug}}/.github/actions/python-poetry-env/action.yml
+++ b/{{cookiecutter.project_slug}}/.github/actions/python-poetry-env/action.yml
@@ -18,4 +18,4 @@ runs:
       shell: bash
     - name: Create virtual environment
       run: poetry install
-      shell: bash{% endraw %}
+      shell: bash{% endraw +%}

--- a/{{cookiecutter.project_slug}}/.github/workflows/cookiecutter.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cookiecutter.yml
@@ -76,4 +76,4 @@ jobs:
           title: "[Actions] Auto-Update cookiecutter template"
           body: ${{ steps.get_changelog.outputs.changelog }}
           branch: chore/auto-update-project-from-template
-          delete-branch: true{% endraw %}
+          delete-branch: true{% endraw +%}

--- a/{{cookiecutter.project_slug}}/.github/workflows/dependencies.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/dependencies.yml
@@ -54,4 +54,4 @@ jobs:
           title: "[Actions] Auto-Update dependencies"
           body: ${{ steps.get_outdated_dependencies.outputs.body }}
           branch: chore/update-dependencies
-          delete-branch: true{% endraw %}
+          delete-branch: true{% endraw +%}

--- a/{{cookiecutter.project_slug}}/.github/workflows/draft_release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/draft_release.yml
@@ -49,4 +49,4 @@ jobs:
           tag_name: ${{ steps.updated_version.outputs.version }}
           release_name: Release ${{ steps.updated_version.outputs.version }}
           body: ${{ steps.changelog.outputs.body }}
-          draft: true{% endraw %}
+          draft: true{% endraw +%}

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -15,4 +15,4 @@ jobs:
           poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
           poetry publish --build --no-interaction
       - name: Deploy docs
-        run: poetry run mkdocs gh-deploy --force{% endraw %}
+        run: poetry run mkdocs gh-deploy --force{% endraw +%}

--- a/{{cookiecutter.project_slug}}/.github/workflows/test.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/python-poetry-env
         with:
-          python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
+          python-version: {% raw %}${{ matrix.python-version }}{% endraw +%}
       - run: poetry run pytest
 
   docs:

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -77,3 +77,10 @@ venv.bak/
 
 # IDEs
 .idea/
+
+# cookiecutter template
+{% if not cookiecutter.releasable %}
+CHANGELOG.md
+.github/workflows/draft_release.yml
+.github/workflows/release.yml
+{% endif %}

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -35,9 +35,11 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+      {% if cookiecutter.releasable %}
       - id: kacl-verify
         name: kacl-verify
         entry: poetry run kacl-cli verify
         language: system
         files: 'CHANGELOG.md'
         pass_filenames: false
+      {% endif %}

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -1,7 +1,7 @@
 # {{ cookiecutter.project_name }}
 
 [![PyPI](https://img.shields.io/pypi/v/{{ cookiecutter.project_slug }}?style=flat-square)](https://pypi.python.org/pypi/{{ cookiecutter.project_slug }}/)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/{{ cookiecutter.project_slug}}?style=flat-square)](https://pypi.python.org/pypi/{{ cookiecutter.project_slug }}/)
+[![Python Version](https://img.shields.io/badge/python-{{ cookiecutter._python_version_specs[cookiecutter.python_version].versions | join("%20|%20") }}-blue.svg)](https://www.python.org/downloads/)
 ![GitHub License](https://img.shields.io/github/license/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug}})
 [![Coookiecutter - Python package](https://img.shields.io/badge/cookiecutter-nekeal-00a86b?style=flat-square&logo=cookiecutter&logoColor=D4AFff&link=https://github.com/nekeal/cookiecutter-python-package)](https://github.com/nekeal/cookiecutter-python-package)
 

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -1,6 +1,8 @@
 # {{ cookiecutter.project_name }}
 
+{% if cookiecutter.releasable %}
 [![PyPI](https://img.shields.io/pypi/v/{{ cookiecutter.project_slug }}?style=flat-square)](https://pypi.python.org/pypi/{{ cookiecutter.project_slug }}/)
+{% endif %}
 [![Python Version](https://img.shields.io/badge/python-{{ cookiecutter._python_version_specs[cookiecutter.python_version].versions | join("%20|%20") }}-blue.svg)](https://www.python.org/downloads/)
 ![GitHub License](https://img.shields.io/github/license/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug}})
 [![Coookiecutter - Python package](https://img.shields.io/badge/cookiecutter-nekeal-00a86b?style=flat-square&logo=cookiecutter&logoColor=D4AFff&link=https://github.com/nekeal/cookiecutter-python-package)](https://github.com/nekeal/cookiecutter-python-package)
@@ -10,8 +12,10 @@
 **Documentation**: [https://{{ cookiecutter.github_username }}.github.io/{{ cookiecutter.project_slug}}](https://{{ cookiecutter.github_username }}.github.io/{{ cookiecutter.project_slug}})
 
 **Source Code**: [https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }})
+{% if cookiecutter.releasable %}
 
 **PyPI**: [https://pypi.org/project/{{ cookiecutter.project_slug }}/](https://pypi.org/project/{{ cookiecutter.project_slug }}/)
+{% endif %}
 
 ---
 
@@ -52,6 +56,8 @@ pytest
 The documentation is automatically generated from the content of the [docs directory](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/tree/master/docs) and from the docstrings
  of the public signatures of the source code. The documentation is updated and published as a [Github Pages page](https://pages.github.com/) automatically as part each release.
 
+{%- if cookiecutter.releasable %}
+
 ### Releasing
 
 Trigger the [Draft release workflow](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/actions/workflows/draft_release.yml)
@@ -61,6 +67,7 @@ Find the draft release from the
 [GitHub releases](https://github.com/{{ cookiecutter.github_username}}/{{ cookiecutter.project_slug }}/releases) and publish it. When
  a release is published, it'll trigger [release](https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/blob/master/.github/workflows/release.yml) workflow which creates PyPI
  release and deploys updated documentation.
+{%- endif %}
 
 ### Pre-commit
 

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/{{ cookiecutter.project_slug }}?style=flat-square)](https://pypi.python.org/pypi/{{ cookiecutter.project_slug }}/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/{{ cookiecutter.project_slug}}?style=flat-square)](https://pypi.python.org/pypi/{{ cookiecutter.project_slug }}/)
-[![PyPI - License](https://img.shields.io/pypi/l/{{ cookiecutter.project_slug }}?style=flat-square)](https://pypi.python.org/pypi/{{ cookiecutter.project_slug }}/)
+![GitHub License](https://img.shields.io/github/license/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug}})
 [![Coookiecutter - Python package](https://img.shields.io/badge/cookiecutter-nekeal-00a86b?style=flat-square&logo=cookiecutter&logoColor=D4AFff&link=https://github.com/nekeal/cookiecutter-python-package)](https://github.com/nekeal/cookiecutter-python-package)
 
 ---

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -41,7 +41,9 @@ pymdown-extensions = "*"
 pytest = "*"
 pytest-github-actions-annotate-failures = "*"
 pytest-cov = "*"
+{% if cookiecutter.releasable %}
 python-kacl = "*"
+{% endif %}
 ruff = "*"
 
 [build-system]


### PR DESCRIPTION
- Replace license badge from pypi to github
- Replace pypi python version badge with a static one
- Add new releasable variable. When false, some parts of the template regarding making a release are not included.


Mai goal of this pull reuqest is to be able to use this template for a python project that does not need to be released to PyPI. When `releasable` variable will be set to `False`:
* some sections of a README will not be included
* `python-kacl` package won't be installed
* Some file regarding releases such as changelog or workflows will be added to .gitignore. 